### PR TITLE
Call the callback of a job if the worker that was processing it died

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Allocates a computation cluster.  Options include:
   * `max_processes` - the maximum number of processes to spawn (default is `ciel(#cpus * 1.25)`)
   * `max_backlog` - the maximum length of the backlog, -1 indicates no limit (default is 10 * max_processes)
                     an error will be returned when max backlog is hit.
-  * `max_request_time` - the maximum amount of time a request should take, in seconds.  An error will be returned when we expect a request will take longer.
+  * `max_request_time` - the maximum amount of time a request should take, in seconds. An error will be returned when we expect a request will take longer.
+  * `max_execution_time` - the maximum amount of time we allow a job to run, in seconds. The worker responsible for this job will be killed if it lasts longer.
 
 Example:
 

--- a/lib/compute-cluster.js
+++ b/lib/compute-cluster.js
@@ -25,6 +25,9 @@ function ComputeCluster(options) {
   if (options.max_request_time && typeof options.max_request_time != 'number') {
     throw "when provided, max_request_time must be a number";
   }
+  if (options.max_execution_time && typeof options.max_execution_time != 'number') {
+    throw "when provided, max_execution_time must be a number";
+  }
 
   events.EventEmitter.call(this);
 
@@ -39,6 +42,7 @@ function ComputeCluster(options) {
   // (negative implies no limit.  careful, there.)
   this._MAX_BACKLOG = options.max_backlog || this._MAX_KIDS * 10;
   this._MAX_REQUEST_TIME = options.max_request_time || 0;
+  this._MAX_EXECUTION_TIME = options.max_execution_time || 0;
   this._work_duration = 0;
   this._jobs_run = 0;
 };
@@ -113,6 +117,9 @@ ComputeCluster.prototype._runWorkOnWorker = function(work, worker) {
   this.emit("debug", "passing compute job to process " + worker.worker.pid);
   var startTime = new Date();
   worker.worker.once('message', function(m) {
+    if(self._MAX_EXECUTION_TIME){
+      clearTimeout(maxExecutionTimeout);
+    }
     // clear the in-progress job
     var cb = worker.job.cb;
     delete worker.job;
@@ -137,6 +144,13 @@ ComputeCluster.prototype._runWorkOnWorker = function(work, worker) {
 
     self._jobs_run++;
   });
+  if(self._MAX_EXECUTION_TIME){
+    var maxExecutionTimeout = setTimeout(function() {
+      self.emit("error", "Job still not finished");
+      worker.worker.kill('SIGKILL');
+    }, self._MAX_EXECUTION_TIME);
+  }
+
   worker.worker.send(work.job);
   worker.job = work;
 };


### PR DESCRIPTION
So that other parts of the application don't wait for the job to be finished (it will never be), but are notified of the failure instead.
Added a unit test too, with a worker that doesn't like to be given work at all.
