### PR TITLE
call callback of the current job with an error when the worker exits

### DIFF
--- a/lib/compute-cluster.js
+++ b/lib/compute-cluster.js
@@ -48,6 +48,11 @@ util.inherits(ComputeCluster, events.EventEmitter);
 ComputeCluster.prototype._onWorkerExit = function(pid) {
   var self = this;
   return function (code) {
+    // inform the callback the process quit
+    var worker = self._kids[pid];
+    if (worker && worker.job && worker.job.cb) {
+      worker.job.cb("compute process (" + pid + ") dies with code: " + code);
+    }
     // if _exiting is false, we don't expect to be shutting down!
     if (!self._exiting) {
       self.emit('error',
@@ -153,7 +158,7 @@ ComputeCluster.prototype.enqueue = function(args, cb) {
     var numWorkers = Object.keys(this._kids).length * 1.0;
     if (numWorkers) {
       // how long would this work take?
-      var expected = ((this._work_q.length / numWorkers) * this._work_duration + this._work_duration) / 1000.0; 
+      var expected = ((this._work_q.length / numWorkers) * this._work_duration + this._work_duration) / 1000.0;
       if (expected > this._MAX_REQUEST_TIME) {
         this.emit('info', "maximum expected work duration hit hit (work would take about " + expected +
                   "s, which is greater than "+ this._MAX_REQUEST_TIME +")!  cannot enqueue!");


### PR DESCRIPTION
When a worker dies while it was working on a job the callback for that job should receive an error so any cleanup can be performed.

My specific use case is with https://github.com/dannycoates/picl-idp/blob/signCheck/routes/sign.js#L67-L87

If the worker dies, the callback should still be called so that the http request can complete.

I'm sorry, I didn't add a unit test, they appear to be broken with node v0.10.21.
